### PR TITLE
MonadGP example

### DIFF
--- a/generic-persistence.cabal
+++ b/generic-persistence.cabal
@@ -29,10 +29,13 @@ source-repository head
 library
   exposed-modules:
       Database.GP
+      Database.GP.Class
+      Database.GP.Class.IO
       Database.GP.Conn
       Database.GP.Entity
       Database.GP.GenericPersistence
       Database.GP.GenericPersistenceSafe
+      Database.GP.Operations
       Database.GP.Query
       Database.GP.SqlGenerator
       Database.GP.TypeInfo

--- a/src/Database/GP/Class.hs
+++ b/src/Database/GP/Class.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Database.GP.Class (MonadGP(..), MonadGPConn(..)) where
+
+import           Data.Convertible                   (Convertible)
+import           Database.GP.Entity                 (Entity)
+
+-- | Class of monads that support database operations over a given connection.
+class Monad m => MonadGP m c where
+  type Id m c
+  selectById :: (Convertible id (Id m c), Entity a) => c -> id -> m (Maybe a)
+  upsert :: Entity a => c -> a -> m ()
+
+-- | Class of monads that can provide a database connection.
+class Monad m => MonadGPConn m c where
+  askConn :: m c

--- a/src/Database/GP/Class/IO.hs
+++ b/src/Database/GP/Class/IO.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# LANGUAGE TypeFamilies #-}
+
+module Database.GP.Class.IO () where
+
+import           Database.GP.Class                  (MonadGP(..))
+import           Database.GP.Conn                   (Conn)
+import qualified Database.GP.GenericPersistence  as GP
+import           Database.HDBC                      (SqlValue)
+
+-- | Default instance provided for 'IO' using HDBC.
+instance MonadGP IO Conn where
+  type Id IO Conn = SqlValue
+  selectById = GP.selectById
+  upsert     = GP.upsert

--- a/src/Database/GP/Operations.hs
+++ b/src/Database/GP/Operations.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+-- | Operations as in 'MonadGP' but without explicit connection passing.
+module Database.GP.Operations (selectById, upsert) where
+
+import           Data.Convertible                   (Convertible)
+import           Database.GP.Entity                 (Entity)
+import           Database.GP.Class                  (Id, MonadGP, MonadGPConn)
+import qualified Database.GP.Class               as GP
+
+selectById :: forall m c id a.
+  (Convertible id (Id m c), Entity a, MonadGP m c, MonadGPConn m c) =>
+  id -> m (Maybe a)
+selectById i = GP.askConn @_ @c >>= flip GP.selectById i
+
+upsert :: forall m c a. (Entity a, MonadGP m c, MonadGPConn m c) => a -> m ()
+upsert a = GP.askConn @_ @c >>= flip GP.upsert a


### PR DESCRIPTION
@thma here is an early example of what I am thinking for #19 

- `MonadGP` supports the operations that are currently in `Database.GP.GenericPersistence` (so far only 2 for demonstration).
- A separate typeclass `MonadGPConn` exists for providing a database connection.
- Putting these two typeclasses together allows for the calling of DB operations (in `Database.GP.Operations`) without explicit passing of a connection parameter, in any monad that supports these operations. For convenience.
- An `instance MonadGP IO Conn` included, simply using your existing functions as the implementation. This instance could have been put in `Database.GP.Class` to avoid an orphan instance warning, however I instead chose to put it in it's own module (and suppress the warning), to ensure separation of the interface and any instance-specific concerns (I am wary to put any DB-related imports in a module that could potentially be imported by some GHCJS frontend code in the future). Note that for this reason the `MonadGP` typeclass is quite abstract.